### PR TITLE
Improve readability of serveral reference architectures

### DIFF
--- a/model/diagrams/id-d932a86d2a4a41e998ae8250a586c1e0/ArchimateDiagramModel_EAID_6CC7B835_7F12_4077_BEA1_B297580772EF.xml
+++ b/model/diagrams/id-d932a86d2a4a41e998ae8250a586c1e0/ArchimateDiagramModel_EAID_6CC7B835_7F12_4077_BEA1_B297580772EF.xml
@@ -86,9 +86,9 @@
           href="AssociationRelationship_EAID_57DA86A0_4257_4d5b_B241_C4A76BDFCB3D.xml#EAID_57DA86A0_4257_4d5b_B241_C4A76BDFCB3D"/>
     </sourceConnections>
     <bounds
-        x="425"
+        x="408"
         y="346"
-        width="105"
+        width="138"
         height="50"/>
     <archimateElement
         xsi:type="archimate:ApplicationService"
@@ -183,9 +183,9 @@
           href="AssociationRelationship_EAID_74189298_B050_443e_9260_64EC92F24240.xml#EAID_74189298_B050_443e_9260_64EC92F24240"/>
     </sourceConnections>
     <bounds
-        x="777"
+        x="756"
         y="346"
-        width="105"
+        width="157"
         height="50"/>
     <archimateElement
         xsi:type="archimate:ApplicationService"
@@ -197,10 +197,10 @@
       targetConnections="EAID_DC000000_7F70_43d3_8B80_8617F86846BE"
       font="1|Calibri|8.0|0|WINDOWS|1|0|0|0|0|0|0|0|0|1|0|0|0|0|Calibri">
     <bounds
-        x="602"
+        x="582"
         y="441"
-        width="105"
-        height="50"/>
+        width="136"
+        height="64"/>
     <archimateElement
         xsi:type="archimate:ApplicationService"
         href="ApplicationService_EAID_7E3A86D4_6EB9_4c93_BE63_7AB915935AC5.xml#EAID_7E3A86D4_6EB9_4c93_BE63_7AB915935AC5"/>


### PR DESCRIPTION
I suggest to improve the readability of the following reference architectures:
- High level DFD w Data Exchange Standards 

And remove the numbers in the name of the following reference architectures:
- 15.4.2 Dynamic Security Assessment
- 4.1.3 Short Term Variable Generation Forecasting
- 4.1.4 Short Term Load Forecasting 
- 4.1.7 Weather Forecasting