### PR TITLE
Add cname to GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,4 @@ jobs:
           archiCsvReportEnabled: true
           archiExportModelEnabled: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cname: architecture.lfenergy.org

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,4 @@ jobs:
           archiCsvReportEnabled: true
           archiExportModelEnabled: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          cname: architecture.lfenergy.org
+          githubPagesDomain: architecture.lfenergy.org


### PR DESCRIPTION
There seems to be a cookie problem with https://architecture.lfenergy.org/ When we deploy a new version of the LF Energy model, you get a 404.

I'm wondering if this is a problem with the build job that deploys the site; it looks like the CNAME file needs to be added there for the custom domain to apply